### PR TITLE
Adding prefix `-loader` to imports-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function getImportsString(query, sourceQuery) {
 
   var importsString = "";
   if (imports.length) {
-    importsString = "imports?" + imports.join(',') + "!";
+    importsString = "imports-loader?" + imports.join(',') + "!";
   }
 
   return importsString;


### PR DESCRIPTION
This change is required to make this loader compatible with webpack 2