### PR TITLE
Update the way of retrieving loader's options

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var slash = require('slash');
 module.exports = function(source, map) {
   this.cacheable && this.cacheable();
 
-  var query = loaderUtils.parseQuery(this.query);
+  var query = loaderUtils.getOptions(this) || {};
   var context = this.context;
   var content = source;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "type": "git",
     "url": "git+https://github.com/shanhaichik/webpack-require-loader.git"
   },
-  "version": "1.3.13",
+  "version": "1.3.14",
   "keywords": [
     "webpack",
     "required-loader",


### PR DESCRIPTION
Updated the way of extracting the given loader options from legacy to recommended way. See more details [here](https://webpack.js.org/api/loaders/#this-query) and [here](https://github.com/webpack/loader-utils#loader-utils).